### PR TITLE
Refactor: extract UI helpers + cancel recurring schedulers

### DIFF
--- a/src/ChatFormatting.cs
+++ b/src/ChatFormatting.cs
@@ -149,11 +149,14 @@ public static class ChatFormatting
 
             // Mirror the text label's resolved opacity onto the star so the fade
             // (driven by the "blurred" class on textLabel) carries to the star.
-            starLabel.schedule.Execute(() =>
+            var opacityTicker = starLabel.schedule.Execute(() =>
             {
                 if (textLabel.panel == null || starLabel.panel == null) return;
                 starLabel.style.opacity = textLabel.resolvedStyle.opacity;
             }).Every(33);
+            // Stop the 30 Hz ticker once the star leaves the panel so it doesn't
+            // keep firing (no-op) for the element's lifetime.
+            starLabel.RegisterCallback<DetachFromPanelEvent>(_ => opacityTicker.Pause());
         }
     }
 

--- a/src/handlers/Visuals/ServerNameAnimation.cs
+++ b/src/handlers/Visuals/ServerNameAnimation.cs
@@ -39,6 +39,7 @@ public static class ServerNameAnimation
         public Color BgColor;
         public Color BgColorHover;
         public bool IsHovered;
+        public IVisualElementScheduledItem Ticker;
     }
 
     [HarmonyPatch(typeof(UIServerBrowser), "StyleServer")]
@@ -174,7 +175,7 @@ public static class ServerNameAnimation
         serverEl.RegisterCallback<MouseEnterEvent>(OnMouseEnter);
         serverEl.RegisterCallback<MouseLeaveEvent>(OnMouseLeave);
 
-        serverEl.schedule
+        state.Ticker = serverEl.schedule
             .Execute(() => UpdateAnimation(serverEl))
             .Every(IntervalMs);
 
@@ -196,6 +197,7 @@ public static class ServerNameAnimation
     private static void StopAnimation(VisualElement serverEl)
     {
         if (!_animatedRows.TryGetValue(serverEl, out var state)) return;
+        state.Ticker?.Pause();
         state.ShimmerOverlay?.RemoveFromHierarchy();
         state.CornerCutTR?.RemoveFromHierarchy();
         state.CornerCutBL?.RemoveFromHierarchy();
@@ -208,6 +210,7 @@ public static class ServerNameAnimation
     {
         if (!_animatedRows.TryGetValue(serverEl, out var state) || serverEl.panel == null)
         {
+            state?.Ticker?.Pause();
             _animatedRows.Remove(serverEl);
             return;
         }
@@ -258,6 +261,8 @@ public static class ServerNameAnimation
         [HarmonyPostfix]
         public static void Postfix()
         {
+            foreach (var state in _animatedRows.Values)
+                state.Ticker?.Pause();
             _animatedRows.Clear();
         }
     }

--- a/src/modifiers/ActiveModifiersHUD.cs
+++ b/src/modifiers/ActiveModifiersHUD.cs
@@ -103,10 +103,7 @@ public static class ActiveModifiersHUD
             var dot = new VisualElement();
             dot.style.width = 6;
             dot.style.height = 6;
-            dot.style.borderTopLeftRadius = 3;
-            dot.style.borderTopRightRadius = 3;
-            dot.style.borderBottomLeftRadius = 3;
-            dot.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(dot, 3);
             dot.style.backgroundColor = new StyleColor(catColor);
             dot.style.marginRight = 6;
             dot.style.flexShrink = 0;

--- a/src/modifiers/AdminTab.cs
+++ b/src/modifiers/AdminTab.cs
@@ -135,10 +135,7 @@ public static class AdminTab
         sendBtn.style.paddingRight = 12;
         sendBtn.style.paddingTop = 4;
         sendBtn.style.paddingBottom = 4;
-        sendBtn.style.borderTopLeftRadius = 0;
-        sendBtn.style.borderTopRightRadius = 0;
-        sendBtn.style.borderBottomLeftRadius = 0;
-        sendBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(sendBtn, 0);
         row.Add(sendBtn);
     }
 
@@ -153,24 +150,14 @@ public static class AdminTab
         row.style.paddingBottom = 5;
         row.style.marginBottom = 2;
         row.style.backgroundColor = new StyleColor(UIHelpers.BgRow);
-        row.style.borderTopLeftRadius = 4;
-        row.style.borderTopRightRadius = 4;
-        row.style.borderBottomLeftRadius = 4;
-        row.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(row, 4);
         parent.Add(row);
 
         // Team dot
         Color teamColor = player.Team == PlayerTeam.Blue
             ? new Color(0.3f, 0.5f, 1f)
             : new Color(0.9f, 0.2f, 0.2f);
-        var dot = new VisualElement();
-        dot.style.width = 8;
-        dot.style.height = 8;
-        dot.style.borderTopLeftRadius = 4;
-        dot.style.borderTopRightRadius = 4;
-        dot.style.borderBottomLeftRadius = 4;
-        dot.style.borderBottomRightRadius = 4;
-        dot.style.backgroundColor = new StyleColor(teamColor);
+        var dot = UIHelpers.MakeDot(teamColor);
         dot.style.marginRight = 8;
         row.Add(dot);
 
@@ -205,10 +192,7 @@ public static class AdminTab
         btn.style.paddingTop = 3;
         btn.style.paddingBottom = 3;
         btn.style.marginLeft = 4;
-        btn.style.borderTopLeftRadius = 0;
-        btn.style.borderTopRightRadius = 0;
-        btn.style.borderBottomLeftRadius = 0;
-        btn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(btn, 0);
 
         btn.RegisterCallback<ClickEvent>(evt =>
         {

--- a/src/modifiers/DonorsTab.cs
+++ b/src/modifiers/DonorsTab.cs
@@ -62,10 +62,7 @@ public static class DonorsTab
         donateBtn.style.paddingTop = 8;
         donateBtn.style.paddingBottom = 8;
         donateBtn.style.marginBottom = 16;
-        donateBtn.style.borderTopLeftRadius = 0;
-        donateBtn.style.borderTopRightRadius = 0;
-        donateBtn.style.borderBottomLeftRadius = 0;
-        donateBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(donateBtn, 0);
         donateBtn.style.alignSelf = Align.FlexStart;
         content.Add(donateBtn);
 
@@ -145,10 +142,7 @@ public static class DonorsTab
         card.style.paddingTop = 5;
         card.style.paddingBottom = 5;
         card.style.marginBottom = 2;
-        card.style.borderTopLeftRadius = 4;
-        card.style.borderTopRightRadius = 4;
-        card.style.borderBottomLeftRadius = 4;
-        card.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(card, 4);
         parent.Add(card);
 
         // Avatar
@@ -156,10 +150,7 @@ public static class DonorsTab
         avatarEl.style.width = 28;
         avatarEl.style.height = 28;
         avatarEl.style.marginRight = 8;
-        avatarEl.style.borderTopLeftRadius = 14;
-        avatarEl.style.borderTopRightRadius = 14;
-        avatarEl.style.borderBottomLeftRadius = 14;
-        avatarEl.style.borderBottomRightRadius = 14;
+        UIHelpers.SetRadius(avatarEl, 14);
         avatarEl.style.backgroundColor = new StyleColor(new Color(0.2f, 0.2f, 0.2f));
         card.Add(avatarEl);
 

--- a/src/modifiers/FeedbackTab.cs
+++ b/src/modifiers/FeedbackTab.cs
@@ -161,10 +161,7 @@ public static class FeedbackTab
         _submitButton.style.paddingBottom = 8;
         _submitButton.style.backgroundColor = new StyleColor(UIHelpers.AccentBlue);
         _submitButton.style.color = UIHelpers.TextPrimary;
-        _submitButton.style.borderTopLeftRadius = 4;
-        _submitButton.style.borderTopRightRadius = 4;
-        _submitButton.style.borderBottomLeftRadius = 4;
-        _submitButton.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(_submitButton, 4);
         UIHelpers.SetBorder(_submitButton, 0, Color.clear);
         buttonRow.Add(_submitButton);
 

--- a/src/modifiers/HomeTab.cs
+++ b/src/modifiers/HomeTab.cs
@@ -86,10 +86,7 @@ public static class HomeTab
         motdButton.style.paddingBottom = 8;
         motdButton.style.marginTop = 8;
         motdButton.style.marginBottom = 4;
-        motdButton.style.borderTopLeftRadius = 0;
-        motdButton.style.borderTopRightRadius = 0;
-        motdButton.style.borderBottomLeftRadius = 0;
-        motdButton.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(motdButton, 0);
         UIHelpers.SetBorder(motdButton, 1, new Color(UIHelpers.AccentBlue.r, UIHelpers.AccentBlue.g, UIHelpers.AccentBlue.b, 0.3f));
 
         motdButton.RegisterCallback<MouseEnterEvent>(evt =>
@@ -196,10 +193,7 @@ public static class HomeTab
         btn.style.paddingBottom = 6;
         btn.style.marginRight = 8;
         btn.style.marginBottom = 6;
-        btn.style.borderTopLeftRadius = 0;
-        btn.style.borderTopRightRadius = 0;
-        btn.style.borderBottomLeftRadius = 0;
-        btn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(btn, 0);
         btn.style.borderTopWidth = 1;
         btn.style.borderBottomWidth = 1;
         btn.style.borderLeftWidth = 1;

--- a/src/modifiers/ModifierControlFactory.cs
+++ b/src/modifiers/ModifierControlFactory.cs
@@ -110,10 +110,7 @@ public static class ModifierControlFactory
         resetBtn.style.paddingRight = 4;
         resetBtn.style.paddingTop = 1;
         resetBtn.style.paddingBottom = 1;
-        resetBtn.style.borderTopLeftRadius = 0;
-        resetBtn.style.borderTopRightRadius = 0;
-        resetBtn.style.borderBottomLeftRadius = 0;
-        resetBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(resetBtn, 0);
         resetBtn.style.marginRight = 4;
 
         var row = new VisualElement();
@@ -222,10 +219,7 @@ public static class ModifierControlFactory
         var teamDot = new VisualElement();
         teamDot.style.width = 8;
         teamDot.style.height = 8;
-        teamDot.style.borderTopLeftRadius = 4;
-        teamDot.style.borderTopRightRadius = 4;
-        teamDot.style.borderBottomLeftRadius = 4;
-        teamDot.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(teamDot, 4);
         teamDot.style.marginLeft = 4;
 
         UpdateTeamDot(teamDot, dropdown.value, players);

--- a/src/modifiers/ModifierListTab.cs
+++ b/src/modifiers/ModifierListTab.cs
@@ -50,10 +50,7 @@ public static class ModifierListTab
             flavorBadge.style.paddingRight = 6;
             flavorBadge.style.paddingTop = 2;
             flavorBadge.style.paddingBottom = 2;
-            flavorBadge.style.borderTopLeftRadius = 3;
-            flavorBadge.style.borderTopRightRadius = 3;
-            flavorBadge.style.borderBottomLeftRadius = 3;
-            flavorBadge.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(flavorBadge, 3);
 
             Color flavorColor = flavor.ToLower() switch
             {
@@ -229,10 +226,7 @@ public static class ModifierListTab
             serversBtn.style.paddingRight = 8;
             serversBtn.style.paddingTop = 2;
             serversBtn.style.paddingBottom = 2;
-            serversBtn.style.borderTopLeftRadius = 3;
-            serversBtn.style.borderTopRightRadius = 3;
-            serversBtn.style.borderBottomLeftRadius = 3;
-            serversBtn.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(serversBtn, 3);
             noticeRow.Add(serversBtn);
 
             var unavailableShownKeys = new HashSet<string>();
@@ -472,10 +466,7 @@ public static class ModifierListTab
         row.style.paddingBottom = 5;
         row.style.marginBottom = 2;
         row.style.backgroundColor = new StyleColor(new Color(0.15f, 0.15f, 0.15f));
-        row.style.borderTopLeftRadius = 4;
-        row.style.borderTopRightRadius = 4;
-        row.style.borderBottomLeftRadius = 4;
-        row.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(row, 4);
         parent.Add(row);
 
         // Favorite star toggle
@@ -508,17 +499,8 @@ public static class ModifierListTab
         row.Add(starBtn);
 
         // Active indicator dot
-        var dot = new VisualElement();
-        dot.style.width = 8;
-        dot.style.height = 8;
-        dot.style.borderTopLeftRadius = 4;
-        dot.style.borderTopRightRadius = 4;
-        dot.style.borderBottomLeftRadius = 4;
-        dot.style.borderBottomRightRadius = 4;
+        var dot = UIHelpers.MakeDot(isActive ? new Color(0.3f, 0.8f, 0.4f) : new Color(0.3f, 0.3f, 0.3f));
         dot.style.marginRight = 10;
-        dot.style.backgroundColor = isActive
-            ? new StyleColor(new Color(0.3f, 0.8f, 0.4f))
-            : new StyleColor(new Color(0.3f, 0.3f, 0.3f));
         row.Add(dot);
 
         // Info column (name + description)
@@ -623,9 +605,6 @@ public static class ModifierListTab
         btn.style.paddingRight = 10;
         btn.style.paddingTop = 4;
         btn.style.paddingBottom = 4;
-        btn.style.borderTopLeftRadius = 0;
-        btn.style.borderTopRightRadius = 0;
-        btn.style.borderBottomLeftRadius = 0;
-        btn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(btn, 0);
     }
 }

--- a/src/modifiers/ModifierPanelUI.cs
+++ b/src/modifiers/ModifierPanelUI.cs
@@ -241,10 +241,7 @@ public static class ModifierPanelUI
         _panel.style.width = new StyleLength(new Length(45, LengthUnit.Percent));
         _panel.style.height = new StyleLength(new Length(70, LengthUnit.Percent));
         _panel.style.backgroundColor = new StyleColor(new Color(0.12f, 0.12f, 0.12f, 0.97f));
-        _panel.style.borderTopLeftRadius = 8;
-        _panel.style.borderTopRightRadius = 8;
-        _panel.style.borderBottomLeftRadius = 8;
-        _panel.style.borderBottomRightRadius = 8;
+        UIHelpers.SetRadius(_panel, 8);
         _panel.style.flexDirection = FlexDirection.Column;
         _panel.style.overflow = Overflow.Hidden;
         _overlay.Add(_panel);
@@ -289,10 +286,7 @@ public static class ModifierPanelUI
         closeButton.style.paddingRight = 8;
         closeButton.style.paddingTop = 4;
         closeButton.style.paddingBottom = 4;
-        closeButton.style.borderTopLeftRadius = 0;
-        closeButton.style.borderTopRightRadius = 0;
-        closeButton.style.borderBottomLeftRadius = 0;
-        closeButton.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(closeButton, 0);
         header.Add(closeButton);
 
         // Tab bar
@@ -346,10 +340,7 @@ public static class ModifierPanelUI
         tabButton.style.paddingTop = 8;
         tabButton.style.paddingBottom = 8;
         tabButton.style.marginRight = 2;
-        tabButton.style.borderTopLeftRadius = 0;
-        tabButton.style.borderTopRightRadius = 0;
-        tabButton.style.borderBottomLeftRadius = 0;
-        tabButton.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(tabButton, 0);
         _tabBar?.Add(tabButton);
 
         _tabs.Add(new TabDefinition

--- a/src/modifiers/PlayersTab.cs
+++ b/src/modifiers/PlayersTab.cs
@@ -132,10 +132,7 @@ public static class PlayersTab
         row.style.paddingTop = 4;
         row.style.paddingBottom = 4;
         row.style.backgroundColor = new StyleColor(UIHelpers.BgRow);
-        row.style.borderTopLeftRadius = 4;
-        row.style.borderTopRightRadius = 4;
-        row.style.borderBottomLeftRadius = 4;
-        row.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(row, 4);
         container.Add(row);
 
         // Expand arrow (placeholder for future accordion use)
@@ -154,10 +151,7 @@ public static class PlayersTab
         avatarContainer.style.width = 24;
         avatarContainer.style.height = 24;
         avatarContainer.style.marginRight = 8;
-        avatarContainer.style.borderTopLeftRadius = 12;
-        avatarContainer.style.borderTopRightRadius = 12;
-        avatarContainer.style.borderBottomLeftRadius = 12;
-        avatarContainer.style.borderBottomRightRadius = 12;
+        UIHelpers.SetRadius(avatarContainer, 12);
         avatarContainer.style.borderTopWidth = 1;
         avatarContainer.style.borderBottomWidth = 1;
         avatarContainer.style.borderLeftWidth = 1;
@@ -225,10 +219,7 @@ public static class PlayersTab
             sgBadge.style.paddingTop = 1;
             sgBadge.style.paddingBottom = 1;
             sgBadge.style.backgroundColor = new StyleColor(new Color(1f, 0.8f, 0f, 0.15f));
-            sgBadge.style.borderTopLeftRadius = 3;
-            sgBadge.style.borderTopRightRadius = 3;
-            sgBadge.style.borderBottomLeftRadius = 3;
-            sgBadge.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(sgBadge, 3);
             nameRow.Add(sgBadge);
         }
 
@@ -245,10 +236,7 @@ public static class PlayersTab
             donorBadge.style.paddingTop = 1;
             donorBadge.style.paddingBottom = 1;
             donorBadge.style.backgroundColor = new StyleColor(new Color(0.28f, 0.50f, 0.90f, 0.15f));
-            donorBadge.style.borderTopLeftRadius = 3;
-            donorBadge.style.borderTopRightRadius = 3;
-            donorBadge.style.borderBottomLeftRadius = 3;
-            donorBadge.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(donorBadge, 3);
             nameRow.Add(donorBadge);
         }
 
@@ -286,10 +274,7 @@ public static class PlayersTab
             modBadge.style.paddingTop = 1;
             modBadge.style.paddingBottom = 1;
             modBadge.style.backgroundColor = new StyleColor(new Color(0.18f, 0.18f, 0.18f));
-            modBadge.style.borderTopLeftRadius = 3;
-            modBadge.style.borderTopRightRadius = 3;
-            modBadge.style.borderBottomLeftRadius = 3;
-            modBadge.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(modBadge, 3);
             row.Add(modBadge);
 
             modBadge.RegisterCallback<MouseEnterEvent>(evt =>
@@ -497,10 +482,7 @@ public static class PlayersTab
             barRow.style.flexDirection = FlexDirection.Row;
             barRow.style.height = 6;
             barRow.style.maxWidth = 150;
-            barRow.style.borderTopLeftRadius = 3;
-            barRow.style.borderTopRightRadius = 3;
-            barRow.style.borderBottomLeftRadius = 3;
-            barRow.style.borderBottomRightRadius = 3;
+            UIHelpers.SetRadius(barRow, 3);
             barRow.style.overflow = Overflow.Hidden;
             teamBarContainer.Add(barRow);
 
@@ -574,10 +556,7 @@ public static class PlayersTab
         tooltip.style.paddingRight = 10;
         tooltip.style.paddingTop = 8;
         tooltip.style.paddingBottom = 8;
-        tooltip.style.borderTopLeftRadius = 4;
-        tooltip.style.borderTopRightRadius = 4;
-        tooltip.style.borderBottomLeftRadius = 4;
-        tooltip.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(tooltip, 4);
         UIHelpers.SetBorder(tooltip, 1, new Color(0.3f, 0.3f, 0.3f));
         tooltip.style.minWidth = 180;
 
@@ -636,10 +615,7 @@ public static class PlayersTab
         pill.style.paddingRight = 6;
         pill.style.paddingTop = 2;
         pill.style.paddingBottom = 2;
-        pill.style.borderTopLeftRadius = 8;
-        pill.style.borderTopRightRadius = 8;
-        pill.style.borderBottomLeftRadius = 8;
-        pill.style.borderBottomRightRadius = 8;
+        UIHelpers.SetRadius(pill, 8);
         pill.style.borderTopWidth = 1;
         pill.style.borderBottomWidth = 1;
         pill.style.borderLeftWidth = 1;
@@ -654,10 +630,7 @@ public static class PlayersTab
         logoEl.style.width = 14;
         logoEl.style.height = 14;
         logoEl.style.marginRight = 4;
-        logoEl.style.borderTopLeftRadius = 7;
-        logoEl.style.borderTopRightRadius = 7;
-        logoEl.style.borderBottomLeftRadius = 7;
-        logoEl.style.borderBottomRightRadius = 7;
+        UIHelpers.SetRadius(logoEl, 7);
         pill.Add(logoEl);
 
         // Proactively fetch logo and update element when ready
@@ -690,10 +663,7 @@ public static class PlayersTab
         btn.style.paddingTop = 2;
         btn.style.paddingBottom = 2;
         btn.style.marginLeft = 3;
-        btn.style.borderTopLeftRadius = 0;
-        btn.style.borderTopRightRadius = 0;
-        btn.style.borderBottomLeftRadius = 0;
-        btn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(btn, 0);
         parent.Add(btn);
     }
 }

--- a/src/modifiers/ServersTab.cs
+++ b/src/modifiers/ServersTab.cs
@@ -60,10 +60,7 @@ public static class ServersTab
         refreshBtn.style.paddingRight = 10;
         refreshBtn.style.paddingTop = 4;
         refreshBtn.style.paddingBottom = 4;
-        refreshBtn.style.borderTopLeftRadius = 0;
-        refreshBtn.style.borderTopRightRadius = 0;
-        refreshBtn.style.borderBottomLeftRadius = 0;
-        refreshBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(refreshBtn, 0);
         headerRow.Add(refreshBtn);
 
         _listContainer = new VisualElement();
@@ -262,23 +259,11 @@ public static class ServersTab
         row.style.paddingBottom = 5;
         row.style.marginBottom = 2;
         row.style.backgroundColor = new StyleColor(UIHelpers.BgRow);
-        row.style.borderTopLeftRadius = 4;
-        row.style.borderTopRightRadius = 4;
-        row.style.borderBottomLeftRadius = 4;
-        row.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(row, 4);
         _listContainer.Add(row);
 
         // Player count dot
-        var dot = new VisualElement();
-        dot.style.width = 8;
-        dot.style.height = 8;
-        dot.style.borderTopLeftRadius = 4;
-        dot.style.borderTopRightRadius = 4;
-        dot.style.borderBottomLeftRadius = 4;
-        dot.style.borderBottomRightRadius = 4;
-        dot.style.backgroundColor = hasPlayers
-            ? new StyleColor(UIHelpers.ActiveGreen)
-            : new StyleColor(new Color(0.3f, 0.3f, 0.3f));
+        var dot = UIHelpers.MakeDot(hasPlayers ? UIHelpers.ActiveGreen : new Color(0.3f, 0.3f, 0.3f));
         dot.style.marginRight = 8;
         row.Add(dot);
 
@@ -378,10 +363,7 @@ public static class ServersTab
         joinBtn.style.paddingRight = 10;
         joinBtn.style.paddingTop = 3;
         joinBtn.style.paddingBottom = 3;
-        joinBtn.style.borderTopLeftRadius = 0;
-        joinBtn.style.borderTopRightRadius = 0;
-        joinBtn.style.borderBottomLeftRadius = 0;
-        joinBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(joinBtn, 0);
         row.Add(joinBtn);
     }
 

--- a/src/modifiers/SettingsTab.cs
+++ b/src/modifiers/SettingsTab.cs
@@ -222,10 +222,7 @@ public static class SettingsTab
         bindButton.style.paddingRight = 12;
         bindButton.style.paddingTop = 4;
         bindButton.style.paddingBottom = 4;
-        bindButton.style.borderTopLeftRadius = 4;
-        bindButton.style.borderTopRightRadius = 4;
-        bindButton.style.borderBottomLeftRadius = 4;
-        bindButton.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(bindButton, 4);
 
         bindButton.RegisterCallback<ClickEvent>(evt =>
         {

--- a/src/modifiers/TrainingTab.cs
+++ b/src/modifiers/TrainingTab.cs
@@ -147,16 +147,7 @@ public static class TrainingTab
         var row = MakeRow(parent);
 
         // Status dot
-        var dot = new VisualElement();
-        dot.style.width = 8;
-        dot.style.height = 8;
-        dot.style.borderTopLeftRadius = 4;
-        dot.style.borderTopRightRadius = 4;
-        dot.style.borderBottomLeftRadius = 4;
-        dot.style.borderBottomRightRadius = 4;
-        dot.style.backgroundColor = isEnabled
-            ? new StyleColor(UIHelpers.ActiveGreen)
-            : new StyleColor(new Color(0.3f, 0.3f, 0.3f));
+        var dot = UIHelpers.MakeDot(isEnabled ? UIHelpers.ActiveGreen : new Color(0.3f, 0.3f, 0.3f));
         dot.style.marginRight = 8;
         row.Add(dot);
 
@@ -211,16 +202,7 @@ public static class TrainingTab
 
         // Status dot
         var anyEnabled = ServerState.BlueDummyEnabled || ServerState.RedDummyEnabled;
-        var dot = new VisualElement();
-        dot.style.width = 8;
-        dot.style.height = 8;
-        dot.style.borderTopLeftRadius = 4;
-        dot.style.borderTopRightRadius = 4;
-        dot.style.borderBottomLeftRadius = 4;
-        dot.style.borderBottomRightRadius = 4;
-        dot.style.backgroundColor = anyEnabled
-            ? new StyleColor(UIHelpers.ActiveGreen)
-            : new StyleColor(new Color(0.3f, 0.3f, 0.3f));
+        var dot = UIHelpers.MakeDot(anyEnabled ? UIHelpers.ActiveGreen : new Color(0.3f, 0.3f, 0.3f));
         dot.style.marginRight = 8;
         row.Add(dot);
 
@@ -267,10 +249,7 @@ public static class TrainingTab
         blueBtn.style.paddingTop = 3;
         blueBtn.style.paddingBottom = 3;
         blueBtn.style.marginRight = 4;
-        blueBtn.style.borderTopLeftRadius = 0;
-        blueBtn.style.borderTopRightRadius = 0;
-        blueBtn.style.borderBottomLeftRadius = 0;
-        blueBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(blueBtn, 0);
         row.Add(blueBtn);
 
         // Red toggle button
@@ -289,10 +268,7 @@ public static class TrainingTab
         redBtn.style.paddingRight = 8;
         redBtn.style.paddingTop = 3;
         redBtn.style.paddingBottom = 3;
-        redBtn.style.borderTopLeftRadius = 0;
-        redBtn.style.borderTopRightRadius = 0;
-        redBtn.style.borderBottomLeftRadius = 0;
-        redBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(redBtn, 0);
         row.Add(redBtn);
     }
 
@@ -399,10 +375,7 @@ public static class TrainingTab
         blueBtn.style.paddingTop = 3;
         blueBtn.style.paddingBottom = 3;
         blueBtn.style.marginRight = 4;
-        blueBtn.style.borderTopLeftRadius = 0;
-        blueBtn.style.borderTopRightRadius = 0;
-        blueBtn.style.borderBottomLeftRadius = 0;
-        blueBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(blueBtn, 0);
         row.Add(blueBtn);
 
         var redBtn = new Button(() =>
@@ -419,10 +392,7 @@ public static class TrainingTab
         redBtn.style.paddingRight = 8;
         redBtn.style.paddingTop = 3;
         redBtn.style.paddingBottom = 3;
-        redBtn.style.borderTopLeftRadius = 0;
-        redBtn.style.borderTopRightRadius = 0;
-        redBtn.style.borderBottomLeftRadius = 0;
-        redBtn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(redBtn, 0);
         row.Add(redBtn);
     }
 
@@ -475,16 +445,7 @@ public static class TrainingTab
         var row = MakeRow(parent);
 
         // Status dot
-        var dot = new VisualElement();
-        dot.style.width = 8;
-        dot.style.height = 8;
-        dot.style.borderTopLeftRadius = 4;
-        dot.style.borderTopRightRadius = 4;
-        dot.style.borderBottomLeftRadius = 4;
-        dot.style.borderBottomRightRadius = 4;
-        dot.style.backgroundColor = isActive
-            ? new StyleColor(UIHelpers.ActiveGreen)
-            : new StyleColor(new Color(0.3f, 0.3f, 0.3f));
+        var dot = UIHelpers.MakeDot(isActive ? UIHelpers.ActiveGreen : new Color(0.3f, 0.3f, 0.3f));
         dot.style.marginRight = 8;
         row.Add(dot);
 
@@ -694,10 +655,7 @@ public static class TrainingTab
         row.style.paddingBottom = 4;
         row.style.marginBottom = 2;
         row.style.backgroundColor = new StyleColor(UIHelpers.BgRow);
-        row.style.borderTopLeftRadius = 4;
-        row.style.borderTopRightRadius = 4;
-        row.style.borderBottomLeftRadius = 4;
-        row.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(row, 4);
         parent.Add(row);
         return row;
     }
@@ -723,9 +681,6 @@ public static class TrainingTab
         btn.style.paddingRight = 10;
         btn.style.paddingTop = 3;
         btn.style.paddingBottom = 3;
-        btn.style.borderTopLeftRadius = 0;
-        btn.style.borderTopRightRadius = 0;
-        btn.style.borderBottomLeftRadius = 0;
-        btn.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(btn, 0);
     }
 }

--- a/src/modifiers/UIHelpers.cs
+++ b/src/modifiers/UIHelpers.cs
@@ -37,6 +37,29 @@ public static class UIHelpers
         return new Color(ri / 255f, gi / 255f, bi / 255f);
     }
 
+    /// <summary>Set all four corner radii of an element to the same value.</summary>
+    public static void SetRadius(VisualElement el, float radius)
+    {
+        el.style.borderTopLeftRadius = radius;
+        el.style.borderTopRightRadius = radius;
+        el.style.borderBottomLeftRadius = radius;
+        el.style.borderBottomRightRadius = radius;
+    }
+
+    /// <summary>
+    /// Create a small circular status dot of the given colour and diameter.
+    /// Caller is responsible for layout (margins, placement).
+    /// </summary>
+    public static VisualElement MakeDot(Color color, float size = 8)
+    {
+        var dot = new VisualElement();
+        dot.style.width = size;
+        dot.style.height = size;
+        SetRadius(dot, size / 2f);
+        dot.style.backgroundColor = new StyleColor(color);
+        return dot;
+    }
+
     public static void SetBorder(VisualElement el, float width, Color color)
     {
         el.style.borderTopWidth = width;

--- a/src/modifiers/VotePopupUI.cs
+++ b/src/modifiers/VotePopupUI.cs
@@ -48,10 +48,7 @@ public static class VotePopupUI
         _container.style.paddingTop = 12;
         _container.style.paddingBottom = 12;
         _container.style.backgroundColor = new StyleColor(new Color(0.1f, 0.1f, 0.1f, 0.85f));
-        _container.style.borderTopLeftRadius = 8;
-        _container.style.borderTopRightRadius = 8;
-        _container.style.borderBottomLeftRadius = 8;
-        _container.style.borderBottomRightRadius = 8;
+        UIHelpers.SetRadius(_container, 8);
         _container.style.flexDirection = FlexDirection.Column;
         _container.style.alignItems = Align.Center;
         _container.style.display = DisplayStyle.None;
@@ -100,10 +97,7 @@ public static class VotePopupUI
         if (progressBg != null)
         {
             progressBg.style.backgroundColor = new StyleColor(new Color(0.2f, 0.2f, 0.2f));
-            progressBg.style.borderTopLeftRadius = 4;
-            progressBg.style.borderTopRightRadius = 4;
-            progressBg.style.borderBottomLeftRadius = 4;
-            progressBg.style.borderBottomRightRadius = 4;
+            UIHelpers.SetRadius(progressBg, 4);
         }
 
         // Style the progress bar fill
@@ -111,10 +105,7 @@ public static class VotePopupUI
         if (progressFill != null)
         {
             progressFill.style.backgroundColor = new StyleColor(new Color(0.4f, 0.7f, 1f));
-            progressFill.style.borderTopLeftRadius = 4;
-            progressFill.style.borderTopRightRadius = 4;
-            progressFill.style.borderBottomLeftRadius = 4;
-            progressFill.style.borderBottomRightRadius = 4;
+            UIHelpers.SetRadius(progressFill, 4);
         }
 
         // Vote bar
@@ -123,10 +114,7 @@ public static class VotePopupUI
         _voteBar.style.height = 20;
         _voteBar.style.marginBottom = 6;
         _voteBar.style.backgroundColor = new StyleColor(new Color(0.15f, 0.15f, 0.15f));
-        _voteBar.style.borderTopLeftRadius = 4;
-        _voteBar.style.borderTopRightRadius = 4;
-        _voteBar.style.borderBottomLeftRadius = 4;
-        _voteBar.style.borderBottomRightRadius = 4;
+        UIHelpers.SetRadius(_voteBar, 4);
         _voteBar.style.overflow = Overflow.Hidden;
         _container.Add(_voteBar);
 
@@ -183,10 +171,7 @@ public static class VotePopupUI
         _yesButton.style.paddingTop = 6;
         _yesButton.style.paddingBottom = 6;
         _yesButton.style.marginRight = 12;
-        _yesButton.style.borderTopLeftRadius = 0;
-        _yesButton.style.borderTopRightRadius = 0;
-        _yesButton.style.borderBottomLeftRadius = 0;
-        _yesButton.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(_yesButton, 0);
         buttonRow.Add(_yesButton);
 
         _noButton = new Button(() => ModifierMessaging.SendCastVote(false));
@@ -199,10 +184,7 @@ public static class VotePopupUI
         _noButton.style.paddingRight = 20;
         _noButton.style.paddingTop = 6;
         _noButton.style.paddingBottom = 6;
-        _noButton.style.borderTopLeftRadius = 0;
-        _noButton.style.borderTopRightRadius = 0;
-        _noButton.style.borderBottomLeftRadius = 0;
-        _noButton.style.borderBottomRightRadius = 0;
+        UIHelpers.SetRadius(_noButton, 0);
         buttonRow.Add(_noButton);
 
         // Result label (hidden until vote ends)


### PR DESCRIPTION
@
Follow-up to #3. Two focused changes, both build clean.

> Stacked on `cleanup/dead-experiments` (#3) so the diff shows only these two commits. Retarget to `main` once #3 merges.

## Extract `SetRadius`/`MakeDot` helpers
The modifier tab files repeated the same four-line corner-radius block ~50 times and hand-built identical circular status dots. Added `UIHelpers.SetRadius(el, r)` and `UIHelpers.MakeDot(color, size)` and adopted them across the tabs:
- 51 four-line radius blocks → single `SetRadius` calls
- 6 hand-built circular dots → `MakeDot`

Net ~170 fewer lines, no behavior change.

## Cancel recurring UI schedulers
Two recurring schedulers kept firing for the element/panel lifetime, only no-opping internally:
- **ChatFormatting**: the per-star 30 Hz opacity-mirror ticker now captures its scheduled item and `Pause()`s on `DetachFromPanelEvent`.
- **ServerNameAnimation**: the ~20 Hz row animation scheduler was never cancelled (`StopAnimation`/`UpdateAnimation`/`RemoveAllServers` just dropped the dict entry). Now stored in `AnimState` and `Pause()`d in all three teardown paths.

## Note on encoding
The radius-block collapse was applied with a regex over the full file text (UTF-8 read/write, preserving BOM/line-endings), and the diffs were verified to contain no mangled non-ASCII (em-dashes, glyphs) before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@